### PR TITLE
:bug: restrict all_questions() to Quizzes

### DIFF
--- a/responseblock/models.py
+++ b/responseblock/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from pagetree.models import PageBlock, Hierarchy
 from django.contrib.contenttypes import generic
 from django import forms
-from quizblock.models import Question
+from quizblock.models import Quiz, Question
 
 
 def all_questions():
@@ -11,7 +11,8 @@ def all_questions():
         for s in h.get_root().get_descendants():
             for p in s.pageblock_set.all():
                 if (hasattr(p.block(), 'needs_submit') and
-                        p.block().needs_submit()):
+                        p.block().needs_submit() and
+                        p.block()._meta.model == Quiz):
                     quizzes.append(p)
 
     for qz in quizzes:


### PR DESCRIPTION
The responseblock code was clearly written when the only blocks in Match with `needs_submit()`
where Quizblocks. Since then, the `CounselingReferral` has crept in. That causes
`all_questions()` to fail as seen here:

https://sentry.ccnmtl.columbia.edu/sentry-internal/match/group/696/

breaking edit pages with a responseblock.

Long term, responseblock should probably use some more abstract approach to getting
the possible questions to choose from so that it could work with any block type
that provides the right API.

In the meantime, just pin it down and make it exclusive to Quizblock's Quizzes.
